### PR TITLE
fix test for rspec 3

### DIFF
--- a/spec/validator_predefined_rules_spec.rb
+++ b/spec/validator_predefined_rules_spec.rb
@@ -6,10 +6,10 @@ describe Focuslight::Validator do
   describe '.rule' do
     it 'returns not_blank predefined rule' do
       r = Focuslight::Validator.rule(:not_blank)
-      expect(r.check(nil)).to be_false
-      expect(r.check("")).to be_false
-      expect(r.check(" ")).to be_false
-      expect(r.check("a")).to be_true
+      expect(r.check(nil)).to be_falsey
+      expect(r.check("")).to be_falsey
+      expect(r.check(" ")).to be_falsey
+      expect(r.check("a")).to be_truthy
 
       expect(r.format("a")).to eql("a")
       expect(r.format(" a ")).to eql("a")
@@ -19,30 +19,30 @@ describe Focuslight::Validator do
 
     it 'returns choice predefined rule' do
       r1 = Focuslight::Validator.rule(:choice, "x", "y", "z")
-      expect(r1.check("a")).to be_false
-      expect(r1.check("x")).to be_true
-      expect(r1.check("z")).to be_true
+      expect(r1.check("a")).to be_falsey
+      expect(r1.check("x")).to be_truthy
+      expect(r1.check("z")).to be_truthy
 
       expect(r1.format("x")).to eql("x")
 
       expect(r1.message).to eql("invalid value")
 
       r2 = Focuslight::Validator.rule(:choice, ["x", "y", "z"])
-      expect(r2.check("a")).to be_false
-      expect(r2.check("x")).to be_true
-      expect(r2.check("z")).to be_true
+      expect(r2.check("a")).to be_falsey
+      expect(r2.check("x")).to be_truthy
+      expect(r2.check("z")).to be_truthy
 
       expect(r2.format("x")).to eql("x")
     end
 
     it 'returns int predefined rule' do
       r = Focuslight::Validator.rule(:int)
-      expect(r.check("0")).to be_true
-      expect(r.check("100")).to be_true
-      expect(r.check("-21")).to be_true
-      expect(r.check("1.0")).to be_false
-      expect(r.check("-3e10")).to be_false
-      expect(r.check("xyz")).to be_false
+      expect(r.check("0")).to be_truthy
+      expect(r.check("100")).to be_truthy
+      expect(r.check("-21")).to be_truthy
+      expect(r.check("1.0")).to be_falsey
+      expect(r.check("-3e10")).to be_falsey
+      expect(r.check("xyz")).to be_falsey
 
       expect(r.format("0")).to eql(0)
       expect(r.format("100")).to eql(100)
@@ -53,12 +53,12 @@ describe Focuslight::Validator do
 
     it 'returns uint predefined rule' do
       r = Focuslight::Validator.rule(:uint)
-      expect(r.check("0")).to be_true
-      expect(r.check("100")).to be_true
-      expect(r.check("-21")).to be_false
-      expect(r.check("1.0")).to be_false
-      expect(r.check("-3e10")).to be_false
-      expect(r.check("xyz")).to be_false
+      expect(r.check("0")).to be_truthy
+      expect(r.check("100")).to be_truthy
+      expect(r.check("-21")).to be_falsey
+      expect(r.check("1.0")).to be_falsey
+      expect(r.check("-3e10")).to be_falsey
+      expect(r.check("xyz")).to be_falsey
 
       expect(r.format("0")).to eql(0)
       expect(r.format("100")).to eql(100)
@@ -68,12 +68,12 @@ describe Focuslight::Validator do
 
     it 'returns natural predefined rule' do
       r = Focuslight::Validator.rule(:natural)
-      expect(r.check("0")).to be_false
-      expect(r.check("100")).to be_true
-      expect(r.check("-21")).to be_false
-      expect(r.check("1.0")).to be_false
-      expect(r.check("-3e10")).to be_false
-      expect(r.check("xyz")).to be_false
+      expect(r.check("0")).to be_falsey
+      expect(r.check("100")).to be_truthy
+      expect(r.check("-21")).to be_falsey
+      expect(r.check("1.0")).to be_falsey
+      expect(r.check("-3e10")).to be_falsey
+      expect(r.check("xyz")).to be_falsey
 
       expect(r.format("0")).to eql(0)
       expect(r.format("100")).to eql(100)
@@ -86,15 +86,15 @@ describe Focuslight::Validator do
       r2 = Focuslight::Validator.rule(:double)
       r3 = Focuslight::Validator.rule(:real)
       [r1, r2, r3].each do |r|
-        expect(r.check("0")).to be_true
-        expect(r.check("0.0")).to be_true
-        expect(r.check("1.0")).to be_true
-        expect(r.check("1e+10")).to be_true
-        expect(r.check("2e-10")).to be_true
-        expect(r.check("-2e-10")).to be_true
-        expect(r.check("e")).to be_false
-        expect(r.check("xyz")).to be_false
-        expect(r.check("")).to be_false
+        expect(r.check("0")).to be_truthy
+        expect(r.check("0.0")).to be_truthy
+        expect(r.check("1.0")).to be_truthy
+        expect(r.check("1e+10")).to be_truthy
+        expect(r.check("2e-10")).to be_truthy
+        expect(r.check("-2e-10")).to be_truthy
+        expect(r.check("e")).to be_falsey
+        expect(r.check("xyz")).to be_falsey
+        expect(r.check("")).to be_falsey
 
         expect(r.format("0")).to eql(0.0)
         expect(r.format("0.0")).to eql(0.0)
@@ -109,20 +109,20 @@ describe Focuslight::Validator do
 
     it 'returns int_range predefined rule' do
       r1 = Focuslight::Validator.rule(:int_range, 0..3)
-      expect(r1.check("0")).to be_true
-      expect(r1.check("1")).to be_true
-      expect(r1.check("3")).to be_true
-      expect(r1.check("-1")).to be_false
+      expect(r1.check("0")).to be_truthy
+      expect(r1.check("1")).to be_truthy
+      expect(r1.check("3")).to be_truthy
+      expect(r1.check("-1")).to be_falsey
 
       expect(r1.format("0")).to eql(0)
 
       expect(r1.message).to eql("invalid number in range 0..3")
 
       r2 = Focuslight::Validator.rule(:int_range, 1..3)
-      expect(r2.check("0")).to be_false
-      expect(r2.check("1")).to be_true
-      expect(r2.check("3")).to be_true
-      expect(r2.check("-1")).to be_false
+      expect(r2.check("0")).to be_falsey
+      expect(r2.check("1")).to be_truthy
+      expect(r2.check("3")).to be_truthy
+      expect(r2.check("-1")).to be_falsey
 
       expect(r2.format("1")).to eql(1)
 
@@ -131,14 +131,14 @@ describe Focuslight::Validator do
 
     it 'returns bool predefined rule, which parse numeric 1/0 as true/false' do
       r = Focuslight::Validator.rule(:bool)
-      expect(r.check("0")).to be_true
-      expect(r.check("1")).to be_true
-      expect(r.check("true")).to be_true
-      expect(r.check("True")).to be_true
-      expect(r.check("false")).to be_true
-      expect(r.check("nil")).to be_false
-      expect(r.check("maru")).to be_false
-      expect(r.check("")).to be_false
+      expect(r.check("0")).to be_truthy
+      expect(r.check("1")).to be_truthy
+      expect(r.check("true")).to be_truthy
+      expect(r.check("True")).to be_truthy
+      expect(r.check("false")).to be_truthy
+      expect(r.check("nil")).to be_falsey
+      expect(r.check("maru")).to be_falsey
+      expect(r.check("")).to be_falsey
 
       expect(r.format("0")).to equal(false)
       expect(r.format("1")).to equal(true)
@@ -151,11 +151,11 @@ describe Focuslight::Validator do
 
     it 'return regexp predefined rule' do
       r = Focuslight::Validator.rule(:regexp, /^[0-9a-f]{4}$/i)
-      expect(r.check("000")).to be_false
-      expect(r.check("0000")).to be_true
-      expect(r.check("00000")).to be_false
-      expect(r.check("a0a0")).to be_true
-      expect(r.check("FFFF")).to be_true
+      expect(r.check("000")).to be_falsey
+      expect(r.check("0000")).to be_truthy
+      expect(r.check("00000")).to be_falsey
+      expect(r.check("a0a0")).to be_truthy
+      expect(r.check("FFFF")).to be_truthy
 
       str = "FfFf"
       expect(r.format(str)).to equal(str)
@@ -165,9 +165,9 @@ describe Focuslight::Validator do
 
     it 'returns rule instance whatever we want with "lambda" rule name' do
       r = Focuslight::Validator.rule(:lambda, ->(v){ v == 'kazeburo' }, "kazeburo only permitted", :to_sym)
-      expect(r.check("kazeburo")).to be_true
-      expect(r.check(" ")).to be_false
-      expect(r.check("tagomoris")).to be_false
+      expect(r.check("kazeburo")).to be_truthy
+      expect(r.check(" ")).to be_falsey
+      expect(r.check("tagomoris")).to be_falsey
 
       expect(r.format("kazeburo")).to eql(:kazeburo)
 

--- a/spec/validator_result_spec.rb
+++ b/spec/validator_result_spec.rb
@@ -5,12 +5,12 @@ require 'focuslight/validator'
 describe Focuslight::Validator::Result do
   it 'indicate that it has errors or not' do
     r = Focuslight::Validator::Result.new
-    expect(r.has_error?).to be_false
+    expect(r.has_error?).to be_falsey
     r.error(:key, "error 1")
-    expect(r.has_error?).to be_true
+    expect(r.has_error?).to be_truthy
     expect(r.errors).to eql({key: "key: error 1"})
     r.error(:key2, "error 2")
-    expect(r.has_error?).to be_true
+    expect(r.has_error?).to be_truthy
     expect(r.errors).to eql({key:"key: error 1", key2:"key2: error 2"})
   end
 

--- a/spec/validator_rule_spec.rb
+++ b/spec/validator_rule_spec.rb
@@ -13,20 +13,20 @@ describe Focuslight::Validator::Rule do
   describe '#check' do
     it 'can validate value with first argument lambda' do
       r1 = Focuslight::Validator::Rule.new(->(v){ v.nil? }, "only nil")
-      expect(r1.check(nil)).to be_true
-      expect(r1.check("str")).to be_false
+      expect(r1.check(nil)).to be_truthy
+      expect(r1.check("str")).to be_falsey
 
       r2 = Focuslight::Validator::Rule.new(->(v){ v.to_i == 1 }, "one")
-      expect(r2.check("0")).to be_false
-      expect(r2.check("1.00")).to be_true
-      expect(r2.check("1")).to be_true
-      expect(r2.check("2")).to be_false
+      expect(r2.check("0")).to be_falsey
+      expect(r2.check("1.00")).to be_truthy
+      expect(r2.check("1")).to be_truthy
+      expect(r2.check("2")).to be_falsey
     end
 
     it 'can receive 2 or more values for lambda arguments if specified' do
       r1 = Focuslight::Validator::Rule.new(->(v1,v2,v3){ v1.to_i > v2.to_i && v2.to_i > v3.to_i }, "order by desc")
-      expect(r1.check("1","2","3")).to be_false
-      expect(r1.check("3","2","1")).to be_true
+      expect(r1.check("1","2","3")).to be_falsey
+      expect(r1.check("3","2","1")).to be_truthy
       expect{ r1.check("3") }.to raise_error(ArgumentError)
 
       r2 = Focuslight::Validator::Rule.new(->(v1){ v1.to_i > 0 }, "greater than zero")

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -12,7 +12,7 @@ describe Focuslight::Validator do
           }
         }
       )
-      expect(result.has_error?).to be_false
+      expect(result.has_error?).to be_falsey
       expect(result.errors).to be_empty
       expect(result.hash).to eql({param1: 'param-01'})
 
@@ -27,7 +27,7 @@ describe Focuslight::Validator do
           }
         }
       )
-      expect(result.has_error?).to be_true
+      expect(result.has_error?).to be_truthy
       expect(result.errors).to eql({key1: "key1: too large num"})
     end
   end
@@ -50,7 +50,7 @@ describe Focuslight::Validator do
       Focuslight::Validator.validate_single(result1, params, :key1, spec1)
       Focuslight::Validator.validate_single(result1, params, :key2, spec1)
       Focuslight::Validator.validate_single(result1, params, :keyx, spec1)
-      expect(result1.has_error?).to be_false
+      expect(result1.has_error?).to be_falsey
       expect(result1[:key1]).to eql("1")
       expect(result1[:key2]).to eql("2")
       expect(result1[:keyx]).to eql("x")
@@ -60,7 +60,7 @@ describe Focuslight::Validator do
       Focuslight::Validator.validate_single(result2, params, :key1, spec2)
       Focuslight::Validator.validate_single(result2, params, :key2, spec2)
       Focuslight::Validator.validate_single(result2, params, :keyx, spec2)
-      expect(result2.has_error?).to be_true
+      expect(result2.has_error?).to be_truthy
       expect(result2[:key1]).to eql(1)
       expect(result2[:key2]).to eql(2)
       expect(result2[:keyx]).to be_nil
@@ -85,7 +85,7 @@ describe Focuslight::Validator do
       Focuslight::Validator.validate_array(result1, params, :key1, spec1)
       Focuslight::Validator.validate_array(result1, params, :key2, spec1)
       Focuslight::Validator.validate_array(result1, params, :key3, spec1)
-      expect(result1.has_error?).to be_false
+      expect(result1.has_error?).to be_falsey
       expect(result1[:key1]).to eql(["0", "1", "2"])
       expect(result1[:key2]).to eql([])
       expect(result1[:key3]).to eql(["kazeburo"])
@@ -95,7 +95,7 @@ describe Focuslight::Validator do
       Focuslight::Validator.validate_array(result2, params, :key1, spec2)
       Focuslight::Validator.validate_array(result2, params, :key2, spec2)
       Focuslight::Validator.validate_array(result2, params, :key3, spec2)
-      expect(result2.has_error?).to be_true
+      expect(result2.has_error?).to be_truthy
       expect(result2[:key1]).to be_nil
       expect(result2[:key2]).to be_nil
       expect(result2[:key3]).to eql(["kazeburo"])
@@ -109,7 +109,7 @@ describe Focuslight::Validator do
       Focuslight::Validator.validate_array(result1, params, :key1, spec1)
       Focuslight::Validator.validate_array(result1, params, :key2, spec1)
       Focuslight::Validator.validate_array(result1, params, :key3, spec1)
-      expect(result1.has_error?).to be_false
+      expect(result1.has_error?).to be_falsey
       expect(result1[:key1]).to eql(["0", "1", "2"])
       expect(result1[:key2]).to eql([])
       expect(result1[:key3]).to eql(["kazeburo"])
@@ -119,7 +119,7 @@ describe Focuslight::Validator do
       Focuslight::Validator.validate_array(result2, params, :key1, spec2)
       Focuslight::Validator.validate_array(result2, params, :key2, spec2)
       Focuslight::Validator.validate_array(result2, params, :key3, spec2)
-      expect(result2.has_error?).to be_true
+      expect(result2.has_error?).to be_truthy
       expect(result2[:key1]).to eql([0, 1, 2])
       expect(result2[:key2]).to eql([])
       expect(result2[:key3]).to be_nil
@@ -139,11 +139,11 @@ describe Focuslight::Validator do
 
       r1 = Focuslight::Validator::Result.new
       Focuslight::Validator.validate_multi_key(r1, params, [:key1, :key2, :key3], spec)
-      expect(r1.has_error?).to be_false
+      expect(r1.has_error?).to be_falsey
 
       r2 = Focuslight::Validator::Result.new
       Focuslight::Validator.validate_multi_key(r2, params, [:key1, :key2, :key4], spec)
-      expect(r2.has_error?).to be_true
+      expect(r2.has_error?).to be_truthy
       expect(r2.errors).to eql({:'key1,key2,key4' => "key1,key2,key4: too large"})
     end
   end


### PR DESCRIPTION
bundler installs rspec version 3 or later, because not specified version in gemspec.
https://github.com/focuslight/focuslight-validator/blob/master/focuslight-validator.gemspec#L23

I fixed tests for rspec version 3. Please confirm.
